### PR TITLE
Establecer Límite de Consultas

### DIFF
--- a/workflows/canned-responses/telegram-faq-bot-rate-limit.json
+++ b/workflows/canned-responses/telegram-faq-bot-rate-limit.json
@@ -19,17 +19,11 @@
       "type": "@n8n/n8n-nodes-langchain.vectorStorePinecone",
       "typeVersion": 1.3,
       "position": [
-        -368,
-        -192
+        0,
+        0
       ],
-      "id": "25aff19a-fabe-43cc-b300-c0a12e83d9c5",
-      "name": "Pinecone Vector Store",
-      "credentials": {
-        "pineconeApi": {
-          "id": "CXZPGPosf8oir6Z5",
-          "name": "PineconeApi account"
-        }
-      }
+      "id": "f6baf4ee-d158-498a-9068-7f702319c3ab",
+      "name": "Pinecone Vector Store"
     },
     {
       "parameters": {
@@ -41,17 +35,17 @@
       "type": "n8n-nodes-base.telegramTrigger",
       "typeVersion": 1.2,
       "position": [
-        -1264,
-        64
+        -896,
+        256
       ],
-      "id": "46a7388f-01de-4cb7-afa0-1bb3b60f418a",
+      "id": "984e4450-ce3b-4911-807e-5f68cfdab260",
       "name": "Cuando Reciba un Mensaje",
       "webhookId": "209c7d7d-cb0d-4a59-b969-765486297ee5",
       "alwaysOutputData": false,
       "credentials": {
         "telegramApi": {
-          "id": "p61m9P3V3Uq6HRZC",
-          "name": "FAMAF Bot"
+          "id": "adn3cue2Jg2A3qbb",
+          "name": "Telegram account"
         }
       }
     },
@@ -60,17 +54,11 @@
       "type": "@n8n/n8n-nodes-langchain.embeddingsGoogleGemini",
       "typeVersion": 1,
       "position": [
-        -304,
-        32
+        64,
+        224
       ],
-      "id": "b154a306-0041-46c8-832e-2aa8de79d22e",
-      "name": "Text-Embedding-004",
-      "credentials": {
-        "googlePalmApi": {
-          "id": "iDKuHCKqSAYAVPK3",
-          "name": "Google Gemini(PaLM) Api account"
-        }
-      }
+      "id": "5113516e-8b42-44dd-90a7-57a34ae58c36",
+      "name": "Text-Embedding-004"
     },
     {
       "parameters": {
@@ -99,10 +87,10 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
-        -16,
-        -96
+        352,
+        96
       ],
-      "id": "b0102c3d-a79d-49b1-9b1e-f1d3dae8b208",
+      "id": "aff34e29-e1c5-4dab-997b-847376e11839",
       "name": "Si Similitud ≥ Punto de Corte"
     },
     {
@@ -117,16 +105,16 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        208,
-        -192
+        576,
+        0
       ],
-      "id": "6ef25ac7-6d08-4b47-bbc7-e4eb3c06dab7",
+      "id": "af7d6316-4a74-41f3-a2c4-c4d9a1a2f384",
       "name": "Responder con la Información Recuperada",
       "webhookId": "5ebe12f0-b3d5-46c0-963a-e24a09fcc843",
       "credentials": {
         "telegramApi": {
-          "id": "p61m9P3V3Uq6HRZC",
-          "name": "FAMAF Bot"
+          "id": "adn3cue2Jg2A3qbb",
+          "name": "Telegram account"
         }
       }
     },
@@ -142,32 +130,32 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        208,
-        16
+        576,
+        208
       ],
-      "id": "fa31d422-0bf9-4a2c-af55-e0f9204db577",
+      "id": "cdfc20f2-eb15-4852-91af-0784cbfc599d",
       "name": "Responder que no hay Suficiente Información",
       "webhookId": "bb1bd8cd-5a0e-4b3e-8f45-4dd46b57ffaa",
       "credentials": {
         "telegramApi": {
-          "id": "p61m9P3V3Uq6HRZC",
-          "name": "FAMAF Bot"
+          "id": "adn3cue2Jg2A3qbb",
+          "name": "Telegram account"
         }
       }
     },
     {
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={\n  \"uid\": \"{{ $json.message.from.id }}\",\n  \"duration_in_sconds\": 60,\n  \"message_limit_per_duration\": 30,\n  \"error_message\": \"⚠️ Realizaste demasiadas peticiones, aguarda un momento e intenalo de nuevo\"\n}",
+        "jsonOutput": "={\n  \"uid\": \"{{ $json.message.from.id }}\",\n  \"duration_in_sconds\": 60,\n  \"message_limit_per_duration\": 30,\n  \"error_message\": \"⚠️ Realizaste demasiadas peticiones, aguarda un momento e inténtalo de nuevo\"\n}",
         "options": {}
       },
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -1040,
-        64
+        -672,
+        256
       ],
-      "id": "2c7881bb-e631-405e-988a-c6247826cecd",
+      "id": "a15fcdca-7584-46fc-a2e3-6561623126d8",
       "name": "Establecer Campos para Rate Limiting"
     },
     {
@@ -182,16 +170,16 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        -256,
-        256
+        112,
+        448
       ],
-      "id": "d190620d-0c02-452e-8f49-1ddb32954985",
+      "id": "9f3e9e66-90e2-4dcc-8618-41beadd55323",
       "name": "Notificar al Usuario que Alcanzó el Límite",
       "webhookId": "bb1bd8cd-5a0e-4b3e-8f45-4dd46b57ffaa",
       "credentials": {
         "telegramApi": {
-          "id": "p61m9P3V3Uq6HRZC",
-          "name": "FAMAF Bot"
+          "id": "adn3cue2Jg2A3qbb",
+          "name": "Telegram account"
         }
       }
     },
@@ -204,16 +192,16 @@
       "type": "n8n-nodes-base.redis",
       "typeVersion": 1,
       "position": [
-        -816,
-        64
+        -448,
+        256
       ],
-      "id": "9d40e7b5-a93a-46de-8c39-f870550a8235",
+      "id": "e50f7c8c-3957-4f75-928f-aa8cc1c77117",
       "name": "Consultar Límite de Usuario",
       "notesInFlow": false,
       "credentials": {
         "redis": {
-          "id": "imdJGkUOtkXqjXkC",
-          "name": "Redis account"
+          "id": "6Y34jq3amyztaE9h",
+          "name": "Redis Cloud - Telegram Bot"
         }
       },
       "onError": "continueErrorOutput"
@@ -245,10 +233,10 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
-        -544,
-        160
+        -176,
+        352
       ],
-      "id": "8a753808-c2e2-4fd7-8296-4bf9b6d8e601",
+      "id": "2381ba7f-1138-4132-addd-6230e1d991f6",
       "name": "¿Está dentro del Límite de Peticiones?"
     },
     {
@@ -260,10 +248,10 @@
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
-        -784,
-        -160
+        -416,
+        32
       ],
-      "id": "6dd860aa-ef2b-4074-96c5-4c24da31f188",
+      "id": "04fb7a94-e1e1-4d12-92c4-a213ab140c70",
       "name": "Sticky Note"
     }
   ],
@@ -396,17 +384,12 @@
   },
   "active": false,
   "settings": {
-    "executionOrder": "v1",
-    "timeSavedMode": "fixed",
-    "callerPolicy": "workflowsFromSameOwner",
-    "executionTimeout": 25,
-    "availableInMCP": false
+    "executionOrder": "v1"
   },
-  "versionId": "2ef901db-54ee-42db-90fc-99d5c3575343",
+  "versionId": "c15a2f24-479f-4193-a065-5463d2050185",
   "meta": {
-    "templateCredsSetupCompleted": true,
-    "instanceId": "6db067c18bbea18af7de927b8d9beea6bfc107e978f808bae57f888340de31de"
+    "instanceId": "5c7a7a1c803a60941291bdab51d4ad63fef182956b74a9df3e2c88d06c52b259"
   },
-  "id": "iza4SH3nnTgMbAcU",
+  "id": "qH8fBb3ZoqaKiUhc",
   "tags": []
 }


### PR DESCRIPTION
Se agrega un workflow `telegram-faq-bot-rate-limit` que utiliza Redis para mantener un contador del número de consultas por usuario (`chatId`)  que se restablece cada 60 segundos. 

Este cambio funciona como una segunda línea de defensa contra ataques DoS a los recursos más costosos.